### PR TITLE
Mark benchmark HTML reports as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+benchmark/results/* linguist-generated=true


### PR DESCRIPTION
So github will not consider entire repo as written in HTML