### PR TITLE
Fix GHC 9.2.1 build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -54,7 +54,7 @@ jobs:
       run: stack bench
 
   hackage-upload:
-    if: github.event_name == 'push' && startsWith(github.event.base_ref, 'refs/heads/master')
+    if: github.event_name == 'push' && startsWith(github.event.base_ref, 'refs/heads/master') && startsWith(github.event.ref, 'refs/tags')
     needs:
       - stack-build
       - cabal-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the `monad-memo` project will be documented in this file
 
+## [0.5.4] - 2022-01-04
+### Fixed
+- Fix GHC 9.2.1 build
+
 ## [0.5.3] - 2020-09-21
 ### Fixed
 - `README.md` links

--- a/Control/Monad/Memo/Array/Instances.hs
+++ b/Control/Monad/Memo/Array/Instances.hs
@@ -12,7 +12,7 @@ Default instances of `ArrayMemo` and `UArrayMemo`
 -}
 
 {-# LANGUAGE NoImplicitPrelude, MultiParamTypeClasses,
-  UndecidableInstances, FlexibleInstances #-}
+  UndecidableInstances, FlexibleInstances, FlexibleContexts #-}
 
 module Control.Monad.Memo.Array.Instances
 (
@@ -27,5 +27,5 @@ import Control.Monad.Memo.Array
 
 
 instance MaybeLike (Maybe v) v => ArrayMemo v (Maybe v)
-        
+
 instance MaybeLike v v => UArrayMemo v v

--- a/Control/Monad/Memo/Vector/Instances.hs
+++ b/Control/Monad/Memo/Vector/Instances.hs
@@ -12,12 +12,12 @@ Default instances for `VectorMemo` and `UVectorMemo`
 -}
 
 {-# LANGUAGE NoImplicitPrelude, MultiParamTypeClasses,
-  UndecidableInstances, FlexibleInstances, TypeFamilies #-}
+  UndecidableInstances, FlexibleInstances, TypeFamilies, FlexibleContexts #-}
 
 module Control.Monad.Memo.Vector.Instances
 (
 
-  
+
 ) where
 
 import Data.Maybe

--- a/monad-memo.cabal
+++ b/monad-memo.cabal
@@ -1,6 +1,6 @@
 Name:               monad-memo
 
-Version:            0.5.3
+Version:            0.5.4
 
 -- A short (one-line) description of the package.
 Synopsis:           Memoization monad transformer
@@ -53,12 +53,13 @@ Build-type:         Simple
 Cabal-version:      >=1.10
 
 Tested-with:
-  GHC==7.8.4,
-  GHC==7.10.3,
-  GHC==8.2.2,
+  GHC==7.8.4
+  GHC==7.10.3
+  GHC==8.2.2
   GHC==8.4.3
   GHC==8.6.5
   GHC==8.8.4
+  GHC==9.2.1
 
 Extra-source-files:
   CHANGELOG.md,


### PR DESCRIPTION
Current version is faling under GHC 9.2.1 build with:
```text
Control/Monad/Memo/Vector/Instances.hs:31:10: error:
    • Non type-variable argument
        in the constraint: MaybeLike (Maybe v) v
      (Use FlexibleContexts to permit this)
    • In the instance declaration for ‘V.VectorMemo v (Maybe v)’
   |
31 | instance MaybeLike (Maybe v) v => V.VectorMemo v (Maybe v)
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```